### PR TITLE
Regenerate VCR Cassette with Sandbox Credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,6 @@ group :test do
   when 'cyber_source'
     gem 'workarea-cyber_source'
   when 'checkoutdotcom'
-    gem 'workarea-checkoutdotcom'
+    gem 'workarea-checkoutdotcom', source: 'https://gems.weblinc.com'
   end
 end

--- a/test/vcr_cassettes/forter/integration/checkoutdotcom_response_code.yml
+++ b/test/vcr_cassettes/forter/integration/checkoutdotcom_response_code.yml
@@ -2,16 +2,16 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sandbox.checkout.com/api2/v2/charges/card
+    uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"autoCapture":"n","value":"0","trackId":null,"currency":"USD","descriptor":{},"card":{"name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiryYear":"2020","expiryMonth":"01"},"email":"user@workarea.com","transactionIndicator":1}'
+      string: '{"capture":false,"amount":"0","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
       - application/json;charset=UTF-8
       Authorization:
-      - sk_test_c4a2323c-3e03-4c02-9988-2906f466b8b5
+      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
       Connection:
       - close
       Accept-Encoding:
@@ -22,31 +22,27 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
     headers:
-      Date:
-      - Thu, 28 Mar 2019 15:26:39 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '1055'
-      Connection:
-      - close
-      Server:
-      - Reblaze Secure Web Gateway
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
+      Content-Length:
+      - '1166'
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
+      Location:
+      - https://api.sandbox.checkout.com/payments/pay_fgnnndfiyquunaubppr3jxfofq
       Product:
       - Gateway
-      Version:
-      - 3.27.4
-      Request-Id:
-      - 00c71b32-36fd-46df-b2b2-bfe75f026eda
+      Cko-Version:
+      - 3.31.11
+      Cko-Request-Id:
+      - 510824d8-13d6-4fcf-b3f8-85aacafede04
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -57,24 +53,32 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Date:
+      - Tue, 10 Sep 2019 18:10:46 GMT
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"id":"charge_test_1E1819BE842N65FA5FE4","liveMode":false,"created":"2019-03-28T15:26:37Z","value":0,"currency":"USD","trackId":null,"description":null,"email":"user@workarea.com","chargeMode":1,"transactionIndicator":1,"customerIp":null,"responseMessage":"Approved","responseAdvancedInfo":"Approved","responseCode":"10000","status":"Card
-        Verified","authCode":"574647","isCascaded":false,"autoCapture":"N","autoCapTime":0.0,"card":{"customerId":"cust_6E3774DC-51F9-492A-A442-ADB96774DA78","expiryMonth":"01","expiryYear":"2020","billingDetails":null,"id":"card_EDD286C1-E6C8-4466-84A8-BE7062007D77","last4":"4242","bin":"424242","paymentMethod":"Visa","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","name":"Ben
-        Crouse","cvvCheck":"Y","avsCheck":"S"},"riskCheck":true,"customerPaymentPlans":null,"metadata":{},"shippingDetails":{"addressLine1":null,"addressLine2":null,"postcode":null,"country":null,"city":null,"state":null,"phone":{}},"products":[],"udf1":null,"udf2":null,"udf3":null,"udf4":null,"udf5":null,"eci":"05"}'
+      string: '{"id":"pay_fgnnndfiyquunaubppr3jxfofq","action_id":"act_fgnnndfiyquunaubppr3jxfofq","amount":0,"currency":"USD","approved":true,"status":"Card
+        Verified","auth_code":"085870","eci":"05","scheme_id":"638500575273231","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_22walxx34p4utlilnus4rlm4l4","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
+        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_pc5upvoxfcte5fvqushqkksf7i","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-09-10T18:10:46Z","processing":{"acquirer_transaction_id":"1434678100","retrieval_reference_number":"221719408493"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_fgnnndfiyquunaubppr3jxfofq"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_fgnnndfiyquunaubppr3jxfofq/actions"}}}'
     http_version: 
-  recorded_at: Thu, 28 Mar 2019 15:26:39 GMT
+  recorded_at: Tue, 10 Sep 2019 18:10:46 GMT
 - request:
     method: post
-    uri: https://sandbox.checkout.com/api2/v2/charges/card
+    uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"autoCapture":"n","value":"500","trackId":"593E2B5D40","currency":"USD","descriptor":{},"cardId":"card_EDD286C1-E6C8-4466-84A8-BE7062007D77","customerId":"cust_6E3774DC-51F9-492A-A442-ADB96774DA78","transactionIndicator":1}'
+      string: '{"capture":false,"amount":"500","reference":"2B2EFCF4F1","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_22walxx34p4utlilnus4rlm4l4","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
       - application/json;charset=UTF-8
       Authorization:
-      - sk_test_c4a2323c-3e03-4c02-9988-2906f466b8b5
+      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
       Connection:
       - close
       Accept-Encoding:
@@ -85,31 +89,27 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
     headers:
-      Date:
-      - Thu, 28 Mar 2019 15:26:40 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '1165'
-      Connection:
-      - close
-      Server:
-      - Reblaze Secure Web Gateway
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
+      Content-Length:
+      - '1390'
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
+      Location:
+      - https://api.sandbox.checkout.com/payments/pay_z4mhqgzybogudjb4x4jo6tf6ha
       Product:
       - Gateway
-      Version:
-      - 3.27.4
-      Request-Id:
-      - c75e1872-b188-4bba-aa17-0608ffbc4eab
+      Cko-Version:
+      - 3.31.11
+      Cko-Request-Id:
+      - ed379e26-63c3-4bf7-af29-b6bda895ee64
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -120,10 +120,17 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Date:
+      - Tue, 10 Sep 2019 18:10:47 GMT
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '{"id":"charge_test_196819BE842W65FA5F12","liveMode":false,"created":"2019-03-28T15:26:40Z","value":500,"currency":"USD","trackId":"593E2B5D40","description":null,"email":"user@workarea.com","chargeMode":1,"transactionIndicator":1,"customerIp":null,"responseMessage":"Approved","responseAdvancedInfo":"Approved","responseCode":"10000","status":"Authorised","authCode":"291930","isCascaded":false,"autoCapture":"N","autoCapTime":0.0,"card":{"customerId":"cust_6E3774DC-51F9-492A-A442-ADB96774DA78","expiryMonth":"01","expiryYear":"2020","billingDetails":{"addressLine1":null,"addressLine2":null,"postcode":null,"country":null,"city":null,"state":null,"phone":{}},"id":"card_EDD286C1-E6C8-4466-84A8-BE7062007D77","last4":"4242","bin":"424242","paymentMethod":"Visa","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","name":"Ben
-        Crouse","cvvCheck":"","avsCheck":"S"},"riskCheck":true,"customerPaymentPlans":null,"metadata":{},"shippingDetails":{"addressLine1":null,"addressLine2":null,"postcode":null,"country":null,"city":null,"state":null,"phone":{}},"products":[],"udf1":null,"udf2":null,"udf3":null,"udf4":null,"udf5":null,"eci":"05"}'
+      string: '{"id":"pay_z4mhqgzybogudjb4x4jo6tf6ha","action_id":"act_z4mhqgzybogudjb4x4jo6tf6ha","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"180212","eci":"05","scheme_id":"768193587887811","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_22walxx34p4utlilnus4rlm4l4","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
+        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_pc5upvoxfcte5fvqushqkksf7i","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-09-10T18:10:47Z","reference":"2B2EFCF4F1","processing":{"acquirer_transaction_id":"1579683508","retrieval_reference_number":"726563618060"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_z4mhqgzybogudjb4x4jo6tf6ha"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_z4mhqgzybogudjb4x4jo6tf6ha/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_z4mhqgzybogudjb4x4jo6tf6ha/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_z4mhqgzybogudjb4x4jo6tf6ha/voids"}}}'
     http_version: 
-  recorded_at: Thu, 28 Mar 2019 15:26:40 GMT
+  recorded_at: Tue, 10 Sep 2019 18:10:47 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
The credentials used by Forter when integrated with CheckoutDotCom are
for the sandbox, so it's OK that they're exposed here in the VCR
cassette.

Fixes #2