### PR TITLE
Set default Forter API version to 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem 'workarea'
+gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.4-stable'
+
 gem 'byebug'
 group :test do
   gem 'simplecov', require: false

--- a/config/initializers/workarea.rb
+++ b/config/initializers/workarea.rb
@@ -5,7 +5,7 @@ Workarea.configure do |config|
   config.forter = ActiveSupport::Configurable::Configuration.new
   config.forter.site_id = nil
 
-  config.forter.api_version = "2.2"
+  config.forter.api_version = "2.3"
 
   config.forter.api_timeout = 2
   config.forter.open_timeout = 2


### PR DESCRIPTION
API version 2.3 allows for the general payment option, which
allows users to pass payment types that are not explicitly supported
by Forter.