### PR TITLE
Only send payment tenders to Forter that have transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem 'workarea', github: 'workarea-commerce/workarea'
+gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.5-stable'
 
 gem 'byebug'
 group :test do

--- a/app/services/workarea/forter/payment.rb
+++ b/app/services/workarea/forter/payment.rb
@@ -10,7 +10,7 @@ module Workarea
 
       # @return Array
       def to_a
-        payment.tenders.map do | tender|
+        payment_tenders.map do | tender|
 
           tender_hash = build_tender_details(tender)
 
@@ -62,18 +62,8 @@ module Workarea
           }
         end
 
-        def credit_used
-          tender = payment.tenders.detect { |t| t.slug == :store_credit }
-          return {} unless tender.present?
-          {
-            creditUsed: {
-              amountUSD: tender.amount.to_s
-            }
-          }
-        end
-
-        def cc_month(month)
-          month < 10 ? "0#{month}" : month.to_s
+        def payment_tenders
+          payment.tenders.reject { |t| t.transactions.empty? }
         end
     end
   end

--- a/test/services/workarea/forter/order_test.rb
+++ b/test/services/workarea/forter/order_test.rb
@@ -84,6 +84,16 @@ module Workarea
         hsh = Forter::Order.new(order).to_h
         assert_equal('1234', hsh[:totalDiscount][:couponCodeUsed])
       end
+
+      def test_to_h_transactionless_tender
+        order = create_placed_order(id: '1234')
+        payment = Workarea::Payment.find('1234')
+        tender = payment.tenders.first
+        tender.transactions = []
+
+        hsh = Forter::Order.new(order).to_h
+        assert_equal(0, hsh[:payment].size)
+      end
     end
   end
 end


### PR DESCRIPTION
Errors we being thrown when Forter was attempting to build transaction data for tenders that do not have any associated transaction. This commit also removes some extraneous code. 

FORTER-1